### PR TITLE
pr/aditighag/test-cleanup

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4404,7 +4404,7 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			"daemonset":          "cilium cilium-node-init",
 			"deployment":         "cilium-operator hubble-relay",
 			"clusterrolebinding": "cilium cilium-operator hubble-relay",
-			"clusterrole":        "cilium cilium-operator hubble-relay",
+			"clusterrole":        "cilium cilium-operator hubble-relay hubble-ui",
 			"serviceaccount":     "cilium cilium-operator hubble-relay",
 			"service":            "cilium-agent hubble-metrics hubble-relay",
 			"secret":             "hubble-relay-client-certs hubble-server-certs hubble-ca-secret",


### PR DESCRIPTION
   Tests can fail with following error if previously
    installed cilium resources exist -
    
    `Error: rendered manifests contain a resource that already exists.
    Unable to continue with install: ClusterRole
    "hubble-ui" in namespace "" exists and cannot be imported into the
    current release: invalid ownership metadata;`
