### PR TITLE
Agent: Get Cilium health config from Hive 

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/health"
+	"github.com/cilium/cilium/pkg/healthconfig"
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -119,6 +120,8 @@ type Daemon struct {
 	// healthEndpointRouting is the information required to set up the health
 	// endpoint's routing in ENI or Azure IPAM mode
 	healthEndpointRouting *linuxrouting.RoutingInfo
+
+	healthConfig healthconfig.CiliumHealthConfig
 
 	ciliumHealth health.CiliumHealthManager
 
@@ -346,6 +349,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		ipsecAgent:        params.IPsecAgent,
 		ciliumHealth:      params.CiliumHealth,
 		endpointAPIFence:  params.EndpointAPIFence,
+		healthConfig:      params.HealthConfig,
 	}
 
 	// initialize endpointRestoreComplete channel as soon as possible so that subsystems

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	"github.com/cilium/cilium/pkg/health"
+	"github.com/cilium/cilium/pkg/healthconfig"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
@@ -1279,6 +1280,7 @@ type daemonParams struct {
 	IPCache             *ipcache.IPCache
 	DirReadStatus       policyDirectory.DirectoryWatcherReadStatus
 	CiliumHealth        health.CiliumHealthManager
+	HealthConfig        healthconfig.CiliumHealthConfig
 	ClusterMesh         *clustermesh.ClusterMesh
 	MonitorAgent        monitorAgent.Agent
 	DB                  *statedb.DB

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -237,7 +237,7 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily, fromK8s,
 func (d *Daemon) allocateHealthIPs() error {
 	bootstrapStats.healthCheck.Start()
 	defer bootstrapStats.healthCheck.End(true)
-	if !option.Config.EnableHealthChecking || !option.Config.EnableEndpointHealthChecking {
+	if !d.healthConfig.IsHealthCheckingEnabled() || !d.healthConfig.IsEndpointHealthCheckingEnabled() {
 		return nil
 	}
 	var healthIPv4, healthIPv6 net.IP

--- a/daemon/cmd/local_node_sync.go
+++ b/daemon/cmd/local_node_sync.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/healthconfig"
+
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -37,6 +39,7 @@ type localNodeSynchronizerParams struct {
 	K8sLocalNode       agentK8s.LocalNodeResource
 	K8sCiliumLocalNode agentK8s.LocalCiliumNodeResource
 	IPsecConfig        datapath.IPsecConfig
+	HealthConfig       healthconfig.CiliumHealthConfig
 }
 
 // localNodeSynchronizer performs the bootstrapping of the LocalNodeStore,
@@ -214,7 +217,8 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 			}
 		}
 
-		if ini.Config.EnableHealthChecking && ini.Config.EnableEndpointHealthChecking {
+		if ini.localNodeSynchronizerParams.HealthConfig.IsHealthCheckingEnabled() &&
+			ini.localNodeSynchronizerParams.HealthConfig.IsEndpointHealthCheckingEnabled() {
 			if ini.Config.EnableIPv4 {
 				node.IPv4HealthIP = net.ParseIP(k8sCiliumNode.Spec.HealthAddressing.IPv4)
 			}


### PR DESCRIPTION
Global configurations can not be completely removed as there are some non-modularized modules (e.g., IPAM) that still reference them.
    
Signed-off-by: Aditi Ghag <aditi@cilium.io>
